### PR TITLE
ci(release): use CHANGESETS_TOKEN (PAT) for changesets/action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # Authenticate as the maintainer (via fine-grained PAT) rather than
+          # the default GITHUB_TOKEN, so the commits and PR that
+          # changesets/action makes from this checkout count as user actions
+          # for the purposes of triggering downstream workflows on the
+          # "Version Packages" PR. With GITHUB_TOKEN GitHub's
+          # no-recursive-workflows rule would suppress CI on those PRs.
+          token: ${{ secrets.CHANGESETS_TOKEN }}
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
@@ -49,5 +56,7 @@ jobs:
           commit: "chore: version packages"
           title: "chore: version packages"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # See checkout step above — same rationale. The PAT is what makes
+          # the bot-opened "Version Packages" PR auto-fire CI checks.
+          GITHUB_TOKEN: ${{ secrets.CHANGESETS_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"


### PR DESCRIPTION
## Summary

Make the Version Packages PR auto-fire CI checks by authenticating `changesets/action` (and the underlying `actions/checkout`) with a fine-grained PAT instead of the default `secrets.GITHUB_TOKEN`.

## Why

GitHub's "no recursive workflows" safety rule suppresses workflow triggers on PRs / pushes authored by `secrets.GITHUB_TOKEN`. In our setup that meant the *Version Packages* PR opened by `changesets/action` (#521 right now) got zero CI checks. Branch protection then blocks merge until checks pass → deadlocked release.

Using a maintainer-owned PAT (`secrets.CHANGESETS_TOKEN`, already configured) makes the bot's commits + PR count as user actions for the purpose of triggering workflows.

## Test plan

- [x] Format / lint / typecheck / build / test / docs:check pass locally
- [ ] CI green on this PR (this is itself a normal user-authored PR, so it doesn't depend on the fix)
- [ ] After merge, close+reopen #521 once to unstick it; future Version Packages PRs are hands-off

## Notes

- PAT permissions (fine-grained, scoped to `ylabonte/procon-ip`):
  - Contents: read+write
  - Pull requests: read+write
  - Workflows: read+write
- Does **not** retroactively rescue PR #521; that one still needs one close+reopen to clear the GITHUB_TOKEN-tainted state.