### PR TITLE
fix(release): bump publish step to Node 24 for OIDC support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,13 @@ jobs:
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          # Node 24 (LTS) ships with npm 11.x. npm Trusted Publishing requires
+          # npm CLI >= 11.5.1 for the OIDC handshake; Node 22 ships with npm 10
+          # which falls back to a (then-empty) NODE_AUTH_TOKEN-based auth, the
+          # registry treats the request as anonymous, and we get a misleading
+          # 404 on PUT. See npm/cli#9088 for the surfaced-diagnostics request.
+          # CI matrix can stay on 20+22 -- this only matters for the publish step.
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
           cache: pnpm
       - run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary

The first attempted v2.0.0 publish (commit \`b9e0fad\` merged from #521) failed with a 404 from npmjs.com even though everything on our side worked:

- ✅ OIDC token minted from the \`release\` environment
- ✅ Provenance attestation signed and uploaded to sigstore
- ❌ \`PUT https://registry.npmjs.org/procon-ip\` → \`404 Not Found\`

After research, the root cause is documented:

**Node 22 ships with npm 10, which doesn't speak the OIDC handshake protocol that npm Trusted Publishing requires (≥ npm 11.5.1).** When the handshake silently fails, the npm CLI falls back to the empty \`NODE_AUTH_TOKEN\` that \`actions/setup-node\` wires up (because of \`registry-url\`), the registry sees an unauthenticated request, and 404s the PUT. npm returns 404 rather than 403 as an information-leak guard.

**Fix**: bump the publish step's \`node-version\` from 22 → 24. Node 24 LTS ships with npm 11.x. Trusted publishing then works end-to-end with the existing PAT + environment + registry-url config — no NPM_TOKEN, no rollback.

## Test plan

- [x] CI green on this PR (this is a small workflow-only change)
- [ ] After merge: re-run release.yml (or push an empty commit). The publish step on Node 24 should succeed; \`npm view procon-ip@2.0.0\` returns 2.0.0 with attestations.

## References

- Medium: ["NPM Trusted Publishing: The 'Weird' 404 Error and the Node.js 24 Fix"](https://medium.com/@kenricktan11/npm-trusted-publishers-the-weird-404-error-and-the-node-js-24-fix-a9f1d717a5dd)
- npm/cli#9088: "Trusted publishing failures report misleading 404 / ENEEDAUTH errors instead of trusted-publishing diagnostics"

## Scope

- Only the **publish** step's Node version changes. The CI matrix (\`ci.yml\`) still tests on Node 20 + 22 — those are the runtimes our consumers target. This change only affects which Node version performs the registry PUT.