### PR TITLE
fix(release): Node 24 publish + CI test/coverage summaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       - run: pnpm coverage
       - name: Publish test results
         if: always() && matrix.node-version == 22
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@v3
         with:
           name: Vitest
           path: test-results/junit.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,10 @@ jobs:
   test:
     name: "Test (Node ${{ matrix.node-version }})"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
     strategy:
       fail-fast: false
       matrix:
@@ -67,6 +71,16 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm coverage
+      - name: Publish test results
+        if: always() && matrix.node-version == 22
+        uses: dorny/test-reporter@v1
+        with:
+          name: Vitest
+          path: test-results/junit.xml
+          reporter: jest-junit
+      - name: Coverage summary
+        if: matrix.node-version == 22
+        uses: davelosert/vitest-coverage-report-action@v2
       - name: Upload coverage
         if: matrix.node-version == 22
         uses: actions/upload-artifact@v7

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 dist
 site
 coverage
+test-results
 
 # Local Node version pin (developer convenience, not a published artefact)
 .nvmrc

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,9 +4,11 @@ export default defineConfig({
   test: {
     environment: 'node',
     include: ['test/**/*.test.ts'],
+    reporters: process.env.CI ? ['default', 'junit'] : ['default'],
+    outputFile: { junit: './test-results/junit.xml' },
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'lcov', 'html'],
+      reporter: ['text', 'lcov', 'html', 'json-summary', 'json'],
       include: ['src/**/*.ts'],
       exclude: ['src/index.ts', '**/*.d.ts'],
       thresholds: {


### PR DESCRIPTION
## Summary
- **release.yml**: bump the publish step to Node 24 so npm CLI 11.5+ does OIDC Trusted Publishing correctly (older npm misses the `id-token` audience when publishing with provenance under certain runner configs).
- **ci.yml**: surface test results + coverage in the Actions summary — `dorny/test-reporter` for a Vitest check-run (junit XML) and `davelosert/vitest-coverage-report-action` for a coverage table in the job summary plus a sticky PR comment with per-file diff vs base.
- **vitest.config.ts**: emit `junit.xml` under CI and add `json-summary` + `json` coverage reporters so both actions have the inputs they need.

## Test plan
- [ ] CI green on this PR (lint, typecheck, build, test on Node 20 + 22, docs)
- [ ] "Vitest" check-run appears with 120 passing tests
- [ ] Coverage table appears in the Node-22 test job's summary
- [ ] Sticky coverage comment shows up on this PR with the per-file diff
- [ ] After merge: next push to master triggers `release.yml` and the publish step runs on Node 24 (will only actually publish when there's a pending changeset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)