### PR TITLE
fix(release): grant checks: write so reusable ci.yml can start

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,12 @@ permissions:
   contents: write
   pull-requests: write
   id-token: write
+  # Needed because release.yml invokes ci.yml via workflow_call, and the test
+  # job there requests checks: write (for dorny/test-reporter). Reusable
+  # workflows can only downgrade caller permissions, never expand them — so
+  # any permission the called job asks for must be granted here too, or the
+  # called workflow fails at startup.
+  checks: write
 
 concurrency:
   group: release-${{ github.ref }}


### PR DESCRIPTION
## Summary
PR #526 added \`checks: write\` to the \`test\` job in \`ci.yml\` (for dorny/test-reporter), but \`release.yml\` invokes \`ci.yml\` via \`workflow_call\` and its top-level permissions didn't include \`checks\`. Reusable workflows can only **downgrade** caller permissions, never expand them — so the first post-merge release run [25708894839](https://github.com/ylabonte/procon-ip/actions/runs/25708894839) hit a \`startup_failure\` (no jobs ever spawned).

Adding \`checks: write\` to \`release.yml\`'s top-level perms unblocks the reusable workflow. Side effect: the dorny + davelosert steps will also run inside release CI runs — harmless (dorny adds a check-run on the merge commit; davelosert skips its PR comment when there's no PR).

## Test plan
- [ ] CI green on this PR
- [ ] After merge: the next push to master triggers Release and gets past startup (the ci-job runs, then the version-or-publish step proceeds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)