### PR TITLE
ci: release on GitHub App token + adopt actions-updater workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,13 +12,3 @@ updates:
       production:
         dependency-type: "production"
     versioning-strategy: "increase"
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    assignees:
-      - "ylabonte"
-    groups:
-      actions:
-        patterns:
-          - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,16 +35,22 @@ jobs:
       name: release
       url: https://www.npmjs.com/package/procon-ip
     steps:
+      # Mint an installation access token from the "release" GitHub App so the
+      # commits and PR that changesets/action pushes are attributed to a bot
+      # identity rather than the default GITHUB_TOKEN. GitHub's
+      # no-recursive-workflows rule suppresses downstream CI for anything pushed
+      # by GITHUB_TOKEN — App tokens (and PATs) are exempt, which is what makes
+      # the bot-opened "Version Packages" PR auto-fire CI checks. The App's
+      # Client ID and private key are stored as repo secrets.
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          # Authenticate as the maintainer (via fine-grained PAT) rather than
-          # the default GITHUB_TOKEN, so the commits and PR that
-          # changesets/action makes from this checkout count as user actions
-          # for the purposes of triggering downstream workflows on the
-          # "Version Packages" PR. With GITHUB_TOKEN GitHub's
-          # no-recursive-workflows rule would suppress CI on those PRs.
-          token: ${{ secrets.CHANGESETS_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
@@ -68,7 +74,8 @@ jobs:
           commit: "chore: version packages"
           title: "chore: version packages"
         env:
-          # See checkout step above — same rationale. The PAT is what makes
-          # the bot-opened "Version Packages" PR auto-fire CI checks.
-          GITHUB_TOKEN: ${{ secrets.CHANGESETS_TOKEN }}
+          # See the App-token step above — same rationale. Reusing the
+          # installation token here is what makes the bot-opened "Version
+          # Packages" PR auto-fire CI checks.
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_CONFIG_PROVENANCE: "true"

--- a/.github/workflows/update-actions.yml
+++ b/.github/workflows/update-actions.yml
@@ -1,0 +1,48 @@
+name: "Update GitHub Actions"
+
+on:
+  schedule:
+    - cron: "0 8 * * 1" # Mondays 08:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: update-actions
+  cancel-in-progress: false
+
+jobs:
+  update:
+    name: "Scan + PR"
+    runs-on: ubuntu-latest
+    steps:
+      # Mint a token from the "release" GitHub App so the auto-opened PR is
+      # authored by a bot identity that DOES trigger downstream CI. With the
+      # default GITHUB_TOKEN, GitHub's no-recursive-workflows rule would
+      # suppress checks on the PR and a human would have to push a no-op
+      # commit to get them running.
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+      - uses: ylabonte/github-actions-updater@v1
+        id: ghau
+        with:
+          write: true
+          commit: true
+      - uses: peter-evans/create-pull-request@v8
+        if: steps.ghau.outputs.changes > 0
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          branch: chore/update-github-actions
+          title: "chore(deps): update GitHub Actions"
+          body: |
+            Automated update of outdated GitHub Actions references.
+            See the commit message for the per-action breakdown.
+          delete-branch: true


### PR DESCRIPTION
## Summary

- **release.yml**: swap fine-grained `CHANGESETS_TOKEN` PAT for an installation access token minted from the "release" GitHub App (`actions/create-github-app-token@v3`). The same token authenticates both the checkout step and `changesets/action`'s `GITHUB_TOKEN` env — keeping the existing behavior that the bot-opened "Version Packages" PR fires downstream CI (GitHub's no-recursive-workflows rule still exempts App tokens, same as PATs).
- **`.github/workflows/update-actions.yml`** (new): Mondays 08:00 UTC + `workflow_dispatch`. Runs `ylabonte/github-actions-updater@v1`, opens a PR via `peter-evans/create-pull-request@v8`. Both steps use the App token so the auto-PR triggers CI without a manual nudge.
- **`.github/dependabot.yml`**: drop the `github-actions` ecosystem block — superseded by the updater workflow. `npm` block unchanged.

Action pins use current majors: `actions/checkout@v6`, `actions/create-github-app-token@v3`, `peter-evans/create-pull-request@v8`, `ylabonte/github-actions-updater@v1`.

## Why App token over PAT

- Scoped per-app, not per-user — no surprises when ylabonte rotates personal credentials.
- Auditable in the App's installation logs.
- v3 of `create-github-app-token` promotes `client-id` over the deprecated `app-id` input.

## Required secrets

Already in place (added before this PR):

- `RELEASE_APP_CLIENT_ID` — the App's Client ID (starts with `Iv23…`).
- `RELEASE_APP_PRIVATE_KEY` — the App's `.pem` private key.

## Test plan

- [ ] CI green on this PR.
- [ ] After merge: next `Release` run mints the App token, runs through changesets (no-op until there's a pending changeset), and completes green. No `CHANGESETS_TOKEN` references in the logs.
- [ ] Smoke-test the updater: Actions tab → "Update GitHub Actions" → "Run workflow" against `master`. If anything is outdated, a PR opens from `github-actions[bot]` with `chore(deps): update GitHub Actions`, and its CI checks start within ~30s (proving the App token triggers downstream runs).
- [ ] After one App-token release has shipped a real version, manually delete `CHANGESETS_TOKEN` repo secret + revoke the underlying PAT.

## Files NOT changed

- `automerge.yml` — only matches Dependabot; auto-updater PRs come from `peter-evans/create-pull-request` and stay human-reviewed for now.
- `CLAUDE.md` — still mentions `CHANGESETS_TOKEN`; will follow up in a small docs commit after this lands and the cutover is verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)