### PR TITLE
chore: raise Node floor to 22, drop Node 20

### DIFF
--- a/.changeset/raise-node-floor.md
+++ b/.changeset/raise-node-floor.md
@@ -1,0 +1,11 @@
+---
+'procon-ip': major
+---
+
+Drop Node 20 support. Minimum supported runtime is now **Node 22 LTS**.
+
+- `engines.node` raised from `>=20.0.0` to `>=22.0.0`.
+- CI matrix bumped from Node 20/22 to Node 22/24.
+- `tsup` compilation target raised from `node20` to `node22`.
+
+**Migration**: bump your runtime to Node 22 LTS or newer.

--- a/.changeset/raise-node-floor.md
+++ b/.changeset/raise-node-floor.md
@@ -1,5 +1,5 @@
 ---
-'procon-ip': major
+'procon-ip': minor
 ---
 
 Drop Node 20 support. Minimum supported runtime is now **Node 22 LTS**.
@@ -8,4 +8,4 @@ Drop Node 20 support. Minimum supported runtime is now **Node 22 LTS**.
 - CI matrix bumped from Node 20/22 to Node 22/24.
 - `tsup` compilation target raised from `node20` to `node22`.
 
-**Migration**: bump your runtime to Node 22 LTS or newer.
+The library's runtime API is unchanged; consumers on Node 22+ are unaffected. Consumers on Node 20 should bump their runtime to Node 22 LTS or newer.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm format:check
@@ -33,7 +33,7 @@ jobs:
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm typecheck
@@ -46,7 +46,7 @@ jobs:
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20, 22]
+        node-version: [22, 24]
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
@@ -72,17 +72,17 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm coverage
       - name: Publish test results
-        if: always() && matrix.node-version == 22
+        if: always() && matrix.node-version == 24
         uses: dorny/test-reporter@v3
         with:
           name: Vitest
           path: test-results/junit.xml
           reporter: jest-junit
       - name: Coverage summary
-        if: matrix.node-version == 22
+        if: matrix.node-version == 24
         uses: davelosert/vitest-coverage-report-action@v2
       - name: Upload coverage
-        if: matrix.node-version == 22
+        if: matrix.node-version == 24
         uses: actions/upload-artifact@v7
         with:
           name: coverage
@@ -96,7 +96,7 @@ jobs:
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm docs:check

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm docs:check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ The package ships **dual ESM + CJS in one tarball** via tsup:
 - `main` points at `./dist/index.cjs`, `module` at `./dist/index.mjs`, `types` at `./dist/index.d.ts`.
 - `files` ships `dist/`, `README.md`, `CHANGELOG.md`, `LICENSE`.
 - Single `tsconfig.json` with `target: ES2022`, `module: ESNext`, `moduleResolution: Bundler`, `strict: true`, `noUncheckedIndexedAccess: true`, `isolatedModules: true`. tsup handles both module emissions from this one source of truth.
-- `tsup.config.ts` defines the build (entry, formats, dts, sourcemaps, target node20).
+- `tsup.config.ts` defines the build (entry, formats, dts, sourcemaps, target node22).
 
 `docs/` holds only the docs front-page source (`docs/index.md`); TypeDoc output goes to `site/` (gitignored) and is uploaded to GitHub Pages by `docs.yml`. **Don't commit `docs/assets/`, `docs/classes/`, etc.** — those were the old hand-regenerated subtree.
 
@@ -90,7 +90,7 @@ Every change ships with a **changeset** (`pnpm changeset` to add one) describing
 
 `.github/workflows/`:
 
-- `ci.yml` — pnpm install + format:check + lint + typecheck + build + coverage + docs:check on Node 20 and 22, on push/PR to `master`/`develop`/`feature/*`. Uploads `coverage/` artifact from the Node 22 job.
+- `ci.yml` — pnpm install + format:check + lint + typecheck + build + coverage + docs:check on Node 22 and 24, on push/PR to `master`/`develop`/`feature/*`. Uploads `coverage/` artifact from the Node 24 job.
 - `docs.yml` — on push to `master` and on release: builds TypeDoc with strict validation, uploads as Pages artifact, deploys to GitHub Pages from Actions (Pages source = "GitHub Actions").
 - `release.yml` — on push to `master`, runs inside the **`release` GitHub environment** (deployment-branch policy restricts to `master`). Uses `changesets/action@v1` to either open a "Version Packages" PR or publish via `npm publish --provenance --access public`. **Publishes via npm Trusted Publishing (OIDC)**: `permissions: id-token: write` + `NPM_CONFIG_PROVENANCE: "true"`. No long-lived `NPM_TOKEN`.
 - `codeql.yml` — JS/TS CodeQL on master + weekly schedule.
@@ -98,7 +98,7 @@ Every change ships with a **changeset** (`pnpm changeset` to add one) describing
 
 Dependabot (`.github/dependabot.yml`) groups npm updates into `production` and `dev-dependencies` (daily), and bumps GitHub Actions weekly.
 
-`.nvmrc` is **gitignored** (developer-local convenience). Node floor is `>=20.0.0` per `engines`.
+`.nvmrc` is **gitignored** (developer-local convenience). Node floor is `>=22.0.0` per `engines`.
 
 ## Workflow conventions for AI agents
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ there are searchable for everyone with a similar question.
 
 ## Installation
 
-Requires **Node 20 LTS or newer**.
+Requires **Node 22 LTS or newer**.
 
 ```bash
 pnpm add procon-ip

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "packageManager": "pnpm@11.1.2",
   "scripts": {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   dts: true,
   sourcemap: true,
   clean: true,
-  target: 'node20',
+  target: 'node22',
   splitting: false,
   treeshake: true,
 });


### PR DESCRIPTION
## Summary

Node 20 ("Iron") enters maintenance EOL April 2026 and is no longer the recommended floor. Raise everything to Node 22 (current LTS) with Node 24 added to the test matrix as the next LTS.

| Surface | Before | After |
|---|---|---|
| \`engines.node\` | \`>=20.0.0\` | \`>=22.0.0\` |
| CI test matrix | \`[20, 22]\` | \`[22, 24]\` |
| CI reporting gates (dorny, davelosert, coverage upload) | \`matrix.node-version == 22\` | \`matrix.node-version == 24\` |
| CI single-version jobs (lint, typecheck, build) | Node 22 | Node 24 |
| \`docs.yml\` | Node 22 | Node 24 |
| \`release.yml\` | Node 24 | (unchanged) |
| \`tsup.config.ts\` target | \`node20\` | \`node22\` |
| README | "Node 20 LTS or newer" | "Node 22 LTS or newer" |
| CLAUDE.md | three references to Node 20 / Node 22 | updated to Node 22 / Node 24 |

## Bump level: minor

The v2.0.0 release was major because of the axios drop and the build-system rewrite, not the Node 18 → 20 floor raise itself. This PR is engines-only — the library's runtime API and emitted output stay compatible with everyone already on Node 22+, so minor is the right call. Consumers still on Node 20 will see install warnings (or hard fails with \`engine-strict\`) rather than runtime breakage.

Changeset is included; the next release will publish 2.1.0.

## Verification

- [x] \`pnpm lint\` — clean
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm build\` — tsup confirms \`Target: node22\`; esm + cjs + dts all succeed
- [x] \`pnpm coverage\` — passes; gates green (lines 98.25%, branches 87.56%, functions 97.45%, statements 97.63%)
- [ ] CI green on this PR — including the new Node 24 matrix entry
- [ ] davelosert sticky coverage comment posts (now from the Node 24 job)
- [ ] dorny "Vitest" check-run appears (now from the Node 24 job)

## Out of scope

- Changing the actual code to use Node-22-only APIs. Nothing requires it today; the floor raise is about supported-runtime contract, not feature adoption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)