### PR TITLE
ci(docs): drop release-published trigger

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,8 +3,6 @@ name: "Docs"
 on:
   push:
     branches: ["master"]
-  release:
-    types: [published]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Drop the \`release: types: [published]\` trigger from \`docs.yml\`. In the changesets release flow, every published release coincides with a push to master (the merge of the "Version Packages" PR), which already triggers the docs build via the \`push.branches: [master]\` trigger. The release-published trigger then fires seconds later under the tag ref (\`v2.1.0\`) and the \`deploy\` job is rejected by the \`github-pages\` environment's branch policy (master-only).

Concretely: the v2.1.0 release just produced [run #26005288961 (push, success)](https://github.com/ylabonte/procon-ip/actions/runs/26005288961) followed by [run #26005314844 (release, failure)](https://github.com/ylabonte/procon-ip/actions/runs/26005314844) — the second deploying the exact same SHA the first one already shipped.

No changeset (CI-only, not published).

## Test plan

- [ ] CI green on this PR
- [ ] Next release produces only one Docs run (the push-triggered one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)