### PR TITLE
fix: isDmxEnabled reads bit 2 (mask 4), add isDmxExtensionEnabled

### DIFF
--- a/.changeset/fix-dmx-enabled-bit.md
+++ b/.changeset/fix-dmx-enabled-bit.md
@@ -1,0 +1,5 @@
+---
+'procon-ip': patch
+---
+
+Fix `GetStateDataSysInfo.isDmxEnabled()`: DMX512 output is bit 2 (mask 4) of `configOtherEnable`, not bit 8 (mask 256). Verified against a real ProCon.IP (`configOtherEnable` reads 0 with DMX off and 4 with DMX on). The old mask reported the separate SPI/DMX *extension* flag, now exposed as the new `isDmxExtensionEnabled()`. This matches the proconip-pypi / Home Assistant behaviour.

--- a/src/get-state-data-sys-info.ts
+++ b/src/get-state-data-sys-info.ts
@@ -253,9 +253,22 @@ export class GetStateDataSysInfo {
   }
 
   /**
-   * Check whether DMX is enabled or not.
+   * Check whether DMX512 output is enabled.
+   *
+   * DMX output is bit 2 of `configOtherEnable` (mask 4), verified against a real
+   * ProCon.IP: `configOtherEnable` reads 0 with DMX off and 4 with DMX on. (The
+   * previous implementation masked bit 8 / 256, which is the separate SPI/DMX
+   * *extension* flag — see {@link isDmxExtensionEnabled}.)
    */
   public isDmxEnabled(): boolean {
+    return (this.configOtherEnable & 4) === 4;
+  }
+
+  /**
+   * Check whether the SPI/DMX extension is enabled (bit 8, mask 256). This is a
+   * different flag from {@link isDmxEnabled} (DMX512 output, bit 2).
+   */
+  public isDmxExtensionEnabled(): boolean {
     return (this.configOtherEnable & 256) === 256;
   }
 }

--- a/test/get-state-data-sys-info.test.ts
+++ b/test/get-state-data-sys-info.test.ts
@@ -83,9 +83,16 @@ describe('GetStateDataSysInfo', () => {
       expect(sysInfoFrom({ configOther: 64 }).isFlowSensorEnabled()).toBe(true);
       expect(sysInfoFrom({ configOther: 0 }).isFlowSensorEnabled()).toBe(false);
     });
-    it('isDmxEnabled = bit 8 (mask 256)', () => {
-      expect(sysInfoFrom({ configOther: 256 }).isDmxEnabled()).toBe(true);
+    it('isDmxEnabled = bit 2 (mask 4)', () => {
+      expect(sysInfoFrom({ configOther: 4 }).isDmxEnabled()).toBe(true);
       expect(sysInfoFrom({ configOther: 0 }).isDmxEnabled()).toBe(false);
+      // bit 8 (the SPI/DMX extension) must NOT be read as DMX output
+      expect(sysInfoFrom({ configOther: 256 }).isDmxEnabled()).toBe(false);
+    });
+    it('isDmxExtensionEnabled = bit 8 (mask 256)', () => {
+      expect(sysInfoFrom({ configOther: 256 }).isDmxExtensionEnabled()).toBe(true);
+      expect(sysInfoFrom({ configOther: 0 }).isDmxExtensionEnabled()).toBe(false);
+      expect(sysInfoFrom({ configOther: 4 }).isDmxExtensionEnabled()).toBe(false);
     });
   });
 


### PR DESCRIPTION
`GetStateDataSysInfo.isDmxEnabled()` masked **bit 8 (256)**, but DMX512 output is **bit 2 (mask 4)** of `configOtherEnable`.

**Verified against a real ProCon.IP:** `configOtherEnable` reads `0` with DMX off and `4` with DMX on.

- `isDmxEnabled()` now returns `(configOtherEnable & 4) === 4`.
- The old bit-8 flag is the separate SPI/DMX *extension*, now exposed as the new **`isDmxExtensionEnabled()`** — matching the split in proconip-pypi / the Home Assistant integration.

Lets consumers (the ioBroker adapter) auto-detect DMX correctly. Test updated + extension test added; 125 tests, build/lint/typecheck green. Patch changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)