### PR TITLE
ci: upgrade changesets/action v1 → v2 (restore tags + GitHub releases)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,15 +67,23 @@ jobs:
       - run: pnpm build
       - name: Create Release Pull Request or Publish
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@v2
         with:
-          publish: pnpm release
-          version: pnpm version-packages
-          commit: "chore: version packages"
-          title: "chore: version packages"
+          publish-script: pnpm release
+          version-script: pnpm version-packages
+          commit-message: "chore: version packages"
+          pr-title: "chore: version packages"
+          # changesets/action v2 no longer reads the token from the GITHUB_TOKEN
+          # env var — it must be passed as the github-token input. Reusing the
+          # App installation token here is what pushes the release commit/tag,
+          # opens the bot-authored "Version Packages" PR (so downstream CI
+          # fires), and creates the GitHub release.
+          #
+          # Why v2: v1 is only compatible with @changesets/cli v1/v2. Once the
+          # CLI was bumped to v3, v1 could no longer parse the publish output,
+          # so it published to npm but silently skipped the git tag and the
+          # GitHub release (e.g. v2.1.2). v2 adds @changesets/cli v3 support and
+          # pushes tags/releases via the GitHub API by default.
+          github-token: ${{ steps.app-token.outputs.token }}
         env:
-          # See the App-token step above — same rationale. Reusing the
-          # installation token here is what makes the bot-opened "Version
-          # Packages" PR auto-fire CI checks.
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_CONFIG_PROVENANCE: "true"


### PR DESCRIPTION
## Why

**v2.1.2 published to npm but got no git tag and no GitHub release** — the first version to regress this way.

**Root cause:** the `@changesets/cli` 2 → 3 dev-dependency bump (#550). `changesets/action@v1` parses `changeset publish`'s stdout to know which packages were published, then pushes the git tags and creates the GitHub releases. `@changesets/cli` v3 changed that output format (`◇ Successfully published:` instead of the old `New tag: …` lines), so v1 detected "0 published packages" and **silently skipped the tag + release**. The npm publish itself is done by `changeset publish` directly, which is why the package still shipped.

Confirmed in the v2.1.2 release run: `🦋 changeset v3.0.1` → `Successfully published: procon-ip@2.1.2` → `Created git tags.` locally, but nothing pushed.

## Fix

Upgrade to **`changesets/action@v2`**, which per its v2.0.0 notes *"Update to Changesets v3 packages"* and drops the old-Changesets compatibility path. v2 also pushes tags/releases via the GitHub API by default.

v2 has breaking config changes, all handled here:
- inputs renamed: `publish`→`publish-script`, `version`→`version-script`, `commit`→`commit-message`, `title`→`pr-title`
- the token is no longer read from the `GITHUB_TOKEN` **env var** — it must be passed via the **`github-token` input** (the App installation token, same as before, so the bot-authored "Version Packages" PR keeps firing downstream CI)
- npm auth stays on **Trusted Publishing (OIDC)**; no `NPM_TOKEN` involved (v2 removed the `.npmrc`/`NPM_TOKEN` path anyway)

`create-github-releases` / `push-git-tags` keep their defaults (both on).

## Note

This PR ensures **future** releases tag + release automatically again. v2.1.2's own missing tag + GitHub release still need to be created out of band (they exist for every prior version) — see the maintainer note in the PR conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)