### PR TITLE
fix: send Authorization with original case (controller 401s lowercase header)

### DIFF
--- a/.changeset/fix-authorization-header-case.md
+++ b/.changeset/fix-authorization-header-case.md
@@ -1,0 +1,5 @@
+---
+'procon-ip': patch
+---
+
+Fix authenticated relay/DMX writes returning **401** against the ProCon.IP controller. `AbstractService.request()` built its headers through the WHATWG `Headers` API, which lowercases every header name, so undici sent `authorization: …` on the wire. The controller's legacy firmware is **case-sensitive on the header name** and rejects a write carrying `authorization`, accepting only `Authorization` (verified end-to-end against a real ProCon.IP V.1.7.6: lowercase → 401, capitalised → 200 `done`). Reads were unaffected because their endpoints ignore auth. Request headers are now assembled as a plain object so their exact casing reaches the wire; a real-wire regression test asserts the outgoing `Authorization` name is capitalised.

--- a/src/abstract-service.ts
+++ b/src/abstract-service.ts
@@ -41,6 +41,22 @@ export interface RequestOptions {
   params?: Record<string, string | number>;
 }
 
+/**
+ * Normalise a {@link HeadersInit} into `[name, value]` pairs, preserving the
+ * caller's original name casing for the plain-object and tuple-array forms. A
+ * WHATWG `Headers` instance has already lowercased its names (unavoidable), but
+ * the service classes never pass one, so case-sensitive headers such as
+ * `Authorization` are unaffected in practice.
+ *
+ * @param init the headers to normalise.
+ * @returns the header entries as `[name, value]` tuples.
+ */
+function toHeaderEntries(init: HeadersInit): [string, string][] {
+  if (init instanceof Headers) return [...init.entries()];
+  if (Array.isArray(init)) return init.map((pair) => [pair[0], pair[1]] as [string, string]);
+  return Object.entries(init);
+}
+
 export abstract class AbstractService {
   protected _config: IServiceConfig;
   protected _requestHeaders: Record<string, string>;
@@ -106,11 +122,22 @@ export abstract class AbstractService {
    */
   protected async request(init: RequestOptions = {}): Promise<Response> {
     const { params, ...restInit } = init;
-    const headers = new Headers(this._requestHeaders);
-    if (restInit.headers) new Headers(restInit.headers).forEach((v, k) => headers.set(k, v));
+    // Assemble the outgoing headers as a plain object so their exact name casing
+    // reaches the wire. WHATWG `Headers` lowercases every header name, but the
+    // controller's legacy firmware is case-sensitive on `Authorization`: it 401s
+    // a write carrying `authorization` and only honours `Authorization`. Routing
+    // request headers through `Headers` (as this once did) therefore broke every
+    // authenticated write, while unauthenticated reads still worked. undici
+    // preserves the casing of a plain-object header map, so we build one by hand.
+    const headers: Record<string, string> = { ...this._requestHeaders };
+    if (restInit.headers) {
+      for (const [name, value] of toHeaderEntries(restInit.headers)) {
+        headers[name] = value;
+      }
+    }
     if (this._config.basicAuth) {
       const creds = `${this._config.username ?? ''}:${this._config.password ?? ''}`;
-      headers.set('Authorization', `Basic ${Buffer.from(creds).toString('base64')}`);
+      headers['Authorization'] = `Basic ${Buffer.from(creds).toString('base64')}`;
     }
 
     const controller = new AbortController();

--- a/test/abstract-service.test.ts
+++ b/test/abstract-service.test.ts
@@ -99,13 +99,17 @@ describe('AbstractService', () => {
     await expect(pending).rejects.not.toBeInstanceOf(ProconIpError);
   });
 
-  it('attaches Authorization header when basicAuth enabled', async () => {
+  it('attaches a capitalised Authorization header when basicAuth enabled', async () => {
     const spy = mockFetchOnce({ status: 200 });
     const svc = new TestService({ ...baseConfig, basicAuth: true, username: 'u', password: 'p' }, new Logger());
     await svc.run();
-    // request() passes a WHATWG `Headers` instance as undici's `headers` option.
-    const headers = spy.mock.calls[0]?.[1]?.headers as unknown as Headers;
-    expect(headers.get('authorization')).toBe('Basic ' + Buffer.from('u:p').toString('base64'));
+    // request() passes a PLAIN OBJECT as undici's `headers` so header-name case
+    // is preserved on the wire — the controller is case-sensitive on the
+    // `Authorization` name and 401s a lowercase `authorization`.
+    const headers = spy.mock.calls[0]?.[1]?.headers as Record<string, string>;
+    expect(headers['Authorization']).toBe('Basic ' + Buffer.from('u:p').toString('base64'));
+    expect(Object.keys(headers)).toContain('Authorization');
+    expect(Object.keys(headers)).not.toContain('authorization');
   });
 
   it('appends params raw (no URL encoding) so literal commas survive', async () => {

--- a/test/abstract-service.wire.test.ts
+++ b/test/abstract-service.wire.test.ts
@@ -41,6 +41,9 @@ class WireService extends AbstractService {
 interface Received {
   method?: string;
   headers: http.IncomingHttpHeaders;
+  // Original on-the-wire header names/values (node lowercases `headers`), needed
+  // to assert case-sensitive header names such as `Authorization`.
+  rawHeaders: string[];
   body: string;
 }
 
@@ -59,6 +62,7 @@ beforeAll(async () => {
       received.push({
         method: req.method,
         headers: req.headers,
+        rawHeaders: req.rawHeaders,
         body: Buffer.concat(chunks).toString('utf8'),
       });
       const respond = (): void => {
@@ -131,6 +135,14 @@ describe('AbstractService real-wire request (undici, no mocks)', () => {
     expect(received).toHaveLength(1);
     const got = received[0]!;
     expect(got.headers['authorization']).toBe('Basic ' + Buffer.from('pooluser:s3cr3t').toString('base64'));
+
+    // The header NAME must reach the wire capitalised as `Authorization`. The
+    // controller's legacy firmware is case-sensitive and 401s a write carrying a
+    // lowercase `authorization` (which WHATWG `Headers` would produce). node
+    // lowercases `req.headers`, so assert against the raw wire names.
+    expect(got.rawHeaders).toContain('Authorization');
+    expect(got.rawHeaders).not.toContain('authorization');
+
     // Even with auth on, the browser headers stay absent.
     expect(got.headers['sec-fetch-mode']).toBeUndefined();
     expect(got.headers['accept-language']).toBeUndefined();


### PR DESCRIPTION
## The bug

Authenticated **relay and DMX writes** to the ProCon.IP return **401**, while reads work. Same credentials (`admin:admin`), same endpoint, from the same host — the browser writes succeed, the adapter's don't.

## Root cause (verified end-to-end against a real ProCon.IP V.1.7.6)

`AbstractService.request()` assembled its headers with the WHATWG `Headers` API, which **lowercases every header name**. undici then sent `authorization: Basic …` on the wire. **The controller's legacy firmware is case-sensitive on the header name** — it 401s a write carrying `authorization` and only honours `Authorization`. Reads were unaffected because their endpoints ignore auth.

Reproduced in isolation with undici against the live controller:

| headers passed to `undici.request` | wire name | result |
|---|---|---|
| `new Headers()` (what the lib did) | `authorization` | **401** |
| plain object `{ Authorization }` | `Authorization` | **200 `done`** |
| array form, capitalised | `Authorization` | **200 `done`** |

And end-to-end through the built `DmxService` against `192.168.2.3`: read `/GetDmx.csv` OK, write `/usrcfg.cgi` → **200 `done`, no 401**.

## Fix

Assemble the outgoing headers as a **plain object** so their exact casing reaches the wire (undici preserves plain-object header-name case) instead of routing them through `Headers`. `Content-Type` and any caller headers keep their casing too.

## Test

Added a real-wire regression assertion: the outgoing `Authorization` name must be capitalised — checked via `req.rawHeaders` (node lowercases `req.headers`, which is exactly why the old wire test couldn't see this). The mock-based unit test now asserts the plain-object header map with a capital `Authorization` key. 125 tests green; build/lint/typecheck pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)