### PR TITLE
fix: use node:http transport so Content-Length reaches the wire capitalised

### DIFF
--- a/.changeset/fix-header-case-node-http.md
+++ b/.changeset/fix-header-case-node-http.md
@@ -1,0 +1,7 @@
+---
+'procon-ip': patch
+---
+
+Fix relay/DMX **writes** being silently dropped by the controller (they returned `200 "done"` but never applied). Root cause: the ProCon.IP's legacy HTTP/1.0 firmware is **case-sensitive on header names** and reads a POST body only when the length header is spelled `Content-Length`. `undici` (and the global `fetch`) lowercase the header names they generate, so every write went out with `content-length` — the firmware ignored the body and no-op'd the write. This is the same class of bug as the `Authorization` casing fixed in 2.1.3, but on a header the HTTP client generates and won't let us re-case.
+
+The HTTP transport is now Node's built-in `http`/`https` (new `src/http-transport.ts`), which preserves the exact casing of every header we set and adds only a capitalised `Host`. **`undici` is removed — the package is now zero runtime dependencies.** Verified end-to-end against a real ProCon.IP V.1.7.6: a `DmxService` write followed by a `GetDmxService` read-back now echoes the written value (previously it stayed unchanged). A real-wire regression test asserts the outgoing `Content-Length` (and `Authorization`) name reaches the wire capitalised.

--- a/package.json
+++ b/package.json
@@ -75,7 +75,5 @@
     "typescript-eslint": "^8.67.0",
     "vitest": "~4.1.11"
   },
-  "dependencies": {
-    "undici": "^8.10.0"
-  }
+  "dependencies": {}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      undici:
-        specifier: ^8.10.0
-        version: 8.10.0
     devDependencies:
       '@changesets/cli':
         specifier: ^3
@@ -1443,10 +1439,6 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@8.10.0:
-    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
-    engines: {node: '>=22.19.0'}
-
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
@@ -2834,8 +2826,6 @@ snapshots:
   ufo@1.6.4: {}
 
   undici-types@8.3.0: {}
-
-  undici@8.10.0: {}
 
   uri-js@4.4.1:
     dependencies:

--- a/src/abstract-service.ts
+++ b/src/abstract-service.ts
@@ -104,10 +104,10 @@ export abstract class AbstractService {
    * a timeout.
    *
    * Only `body`, `headers`, and `signal` from `init` are honoured — the
-   * request is issued via Node's built-in http/https ({@link httpRequest}), not
-   * the global `fetch()` or `undici`, both of which mangle header-name casing
-   * the controller's firmware depends on. Caller `headers` are merged on top of
-   * the service's `_requestHeaders`.
+   * request is issued via Node's built-in http/https (`httpRequest`), not the
+   * global `fetch()` or `undici`, both of which mangle header-name casing the
+   * controller's firmware depends on. Caller `headers` are merged on top of the
+   * service's `_requestHeaders`.
    *
    * @param init Optional `fetch` init plus a `params` shortcut. `params`,
    *   if provided, is serialised as `key=value&key=value` and appended to
@@ -126,8 +126,8 @@ export abstract class AbstractService {
     // reaches the wire. The controller's legacy firmware is case-sensitive on
     // header names: it 401s a write carrying `authorization` (only `Authorization`
     // is honoured) and ignores the body of a write carrying `content-length`
-    // (only `Content-Length` is honoured). {@link httpRequest} preserves the
-    // casing of this plain-object map, so we build it by hand.
+    // (only `Content-Length` is honoured). `httpRequest` preserves the casing of
+    // this plain-object map, so we build it by hand.
     const headers: Record<string, string> = { ...this._requestHeaders };
     if (restInit.headers) {
       for (const [name, value] of toHeaderEntries(restInit.headers)) {

--- a/src/abstract-service.ts
+++ b/src/abstract-service.ts
@@ -3,7 +3,7 @@
  * @packageDocumentation
  */
 
-import { request as undiciRequest } from 'undici';
+import { httpRequest } from './http-transport';
 import { BadCredentialsError, BadStatusCodeError, ProconIpError, RequestTimeoutError } from './errors';
 import type { ILogger } from './logger';
 
@@ -30,9 +30,8 @@ export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'HEAD' | 
 /**
  * Options for {@link AbstractService.request}. Deliberately narrower than
  * `RequestInit`: only a string `body`, `headers` and `signal` are honoured
- * (a non-string body such as `URLSearchParams` would fail inside
- * `undici.request()` — and, for these legacy endpoints, must never be
- * percent-encoded anyway), plus the raw `params` query-string shortcut.
+ * (for these legacy endpoints a body must never be percent-encoded), plus the
+ * raw `params` query-string shortcut.
  */
 export interface RequestOptions {
   body?: string;
@@ -105,9 +104,10 @@ export abstract class AbstractService {
    * a timeout.
    *
    * Only `body`, `headers`, and `signal` from `init` are honoured — the
-   * request is issued via `undici.request()` (not the global `fetch()`, which
-   * would inject browser headers the controller mishandles). Caller `headers`
-   * are merged on top of the service's `_requestHeaders`.
+   * request is issued via Node's built-in http/https ({@link httpRequest}), not
+   * the global `fetch()` or `undici`, both of which mangle header-name casing
+   * the controller's firmware depends on. Caller `headers` are merged on top of
+   * the service's `_requestHeaders`.
    *
    * @param init Optional `fetch` init plus a `params` shortcut. `params`,
    *   if provided, is serialised as `key=value&key=value` and appended to
@@ -123,12 +123,11 @@ export abstract class AbstractService {
   protected async request(init: RequestOptions = {}): Promise<Response> {
     const { params, ...restInit } = init;
     // Assemble the outgoing headers as a plain object so their exact name casing
-    // reaches the wire. WHATWG `Headers` lowercases every header name, but the
-    // controller's legacy firmware is case-sensitive on `Authorization`: it 401s
-    // a write carrying `authorization` and only honours `Authorization`. Routing
-    // request headers through `Headers` (as this once did) therefore broke every
-    // authenticated write, while unauthenticated reads still worked. undici
-    // preserves the casing of a plain-object header map, so we build one by hand.
+    // reaches the wire. The controller's legacy firmware is case-sensitive on
+    // header names: it 401s a write carrying `authorization` (only `Authorization`
+    // is honoured) and ignores the body of a write carrying `content-length`
+    // (only `Content-Length` is honoured). {@link httpRequest} preserves the
+    // casing of this plain-object map, so we build it by hand.
     const headers: Record<string, string> = { ...this._requestHeaders };
     if (restInit.headers) {
       for (const [name, value] of toHeaderEntries(restInit.headers)) {
@@ -171,18 +170,12 @@ export abstract class AbstractService {
     }
 
     try {
-      // NOTE: we intentionally use undici.request(), NOT the global fetch().
-      // The WHATWG fetch() implementation injects browser-only request headers
-      // (`sec-fetch-mode`, `accept-language`, `accept`, `user-agent`) that the
-      // controller's legacy firmware mishandles: it answers a relay/DMX write
-      // with "200 done" but silently ignores it (reads over fetch work fine).
-      // Those headers are on the fetch "forbidden header" list and cannot be
-      // stripped via the API, so we bypass fetch entirely. undici.request()
-      // sends only the headers assembled above (plus the standard host /
-      // content-length / connection every HTTP client adds — note `connection:
-      // keep-alive` is NOT a culprit here; undici sends it too). See the
-      // regression test in `test/abstract-service.wire.test.ts`.
-      const res = await undiciRequest(url, {
+      // Issue the request via Node's built-in http/https (see ./http-transport).
+      // The controller's legacy firmware is case-sensitive on header names, which
+      // both the global fetch() and undici break by lowercasing the header names
+      // they generate (a lowercase `content-length` makes the firmware drop the
+      // body and silently no-op the write while still answering 200 "done").
+      const res = await httpRequest(url, {
         method: this._method,
         headers,
         body: restInit.body,
@@ -190,28 +183,23 @@ export abstract class AbstractService {
       });
       const status = res.statusCode;
       if (status === 401 || status === 403) {
-        await res.body.dump();
         throw new BadCredentialsError(`Authentication failed (HTTP ${status})`);
       }
       if (status < 200 || status >= 300) {
-        await res.body.dump();
         throw new BadStatusCodeError(`Request failed: HTTP ${status}`, status, String(status));
       }
       // 204/205 are "null body status" codes: `new Response()` rejects a
-      // non-null body for them, so a successful 204 would otherwise crash with
-      // an opaque TypeError. Drain the (empty) stream and return a null body.
+      // non-null body for them, so return an explicit null body.
       if (status === 204 || status === 205) {
-        await res.body.dump();
         return new Response(null, { status });
       }
-      // Read the body eagerly (consuming the undici stream) and re-wrap it in a
-      // standard `Response` so the return contract is unchanged for callers.
-      const text = await res.body.text();
-      return new Response(text, { status });
+      // Re-wrap the already-read body in a standard `Response` so the return
+      // contract is unchanged for callers.
+      return new Response(res.text, { status });
     } catch (e: unknown) {
       const name = e instanceof Error ? e.name : '';
       const code = (e as { code?: string } | null)?.code;
-      if (name === 'AbortError' || code === 'UND_ERR_ABORTED') {
+      if (name === 'AbortError' || code === 'ABORT_ERR') {
         // Caller-driven abort: re-throw the original error so consumers can
         // distinguish it from our timeout.
         if (externalSignal?.aborted) throw e;

--- a/src/http-transport.ts
+++ b/src/http-transport.ts
@@ -27,7 +27,7 @@
 import http from 'node:http';
 import https from 'node:https';
 
-/** Options for {@link httpRequest}. */
+/** Options for `httpRequest`. */
 export interface HttpRequestOptions {
   /** HTTP method (e.g. `"GET"` / `"POST"`). */
   method: string;

--- a/src/http-transport.ts
+++ b/src/http-transport.ts
@@ -1,0 +1,89 @@
+/**
+ * Low-level HTTP transport for the ProCon.IP service classes.
+ *
+ * Uses Node's built-in `http`/`https` — **not** `undici` and **not** the global
+ * `fetch()`. The controller runs a legacy HTTP/1.0 firmware that is
+ * **case-sensitive on request header names**: it only honours `Authorization`
+ * and `Content-Length` spelled with that exact capitalisation.
+ *
+ *   - `fetch()` lowercases header names *and* injects browser-only headers
+ *     (`sec-fetch-*`, `accept-language`, `user-agent`, …) that the firmware
+ *     mishandles.
+ *   - `undici.request()` lowercases the header names it generates
+ *     (`content-length`, `host`, `connection`) and overrides an explicit
+ *     `Content-Length`. A lowercase `content-length` makes the firmware ignore
+ *     the request body entirely — the write is dropped but still answered
+ *     `200 "done"`, so relay/DMX writes silently no-op.
+ *
+ * Node's `http.request()` sends only the headers we set, preserving their case,
+ * plus a capitalised `Host`. We set `Content-Length` (capitalised) explicitly
+ * for requests that carry a body, and `Connection: close` (the controller
+ * closes the socket anyway) — the exact minimal, case-correct request the
+ * firmware accepts, verified on a real ProCon.IP V.1.7.6.
+ *
+ * @packageDocumentation
+ */
+
+import http from 'node:http';
+import https from 'node:https';
+
+/** Options for {@link httpRequest}. */
+export interface HttpRequestOptions {
+  /** HTTP method (e.g. `"GET"` / `"POST"`). */
+  method: string;
+  /** Request headers, sent with their exact name casing preserved. */
+  headers: Record<string, string>;
+  /** Optional string request body. */
+  body?: string;
+  /** Optional abort signal (fires on timeout or caller abort). */
+  signal?: AbortSignal;
+}
+
+/** The subset of the HTTP response the services consume. */
+export interface HttpResponse {
+  /** Numeric HTTP status code. */
+  statusCode: number;
+  /** The fully-read response body as text. */
+  text: string;
+}
+
+/**
+ * Issue a single HTTP request via Node's built-in `http`/`https`, preserving the
+ * exact casing of every request header name (required by the controller's
+ * case-sensitive firmware). Reads the whole response body into a string.
+ *
+ * @param url the absolute request URL.
+ * @param opts method, headers, optional body and abort signal.
+ * @returns the status code and the response body text.
+ */
+export function httpRequest(url: string, opts: HttpRequestOptions): Promise<HttpResponse> {
+  const target = new URL(url);
+  const transport = target.protocol === 'https:' ? https : http;
+  const headers: Record<string, string> = { ...opts.headers };
+
+  // The firmware needs a capitalised `Content-Length` to read the body; set it
+  // ourselves so Node emits exactly that header (never a lowercase or chunked
+  // framing). Only for requests that actually carry a body.
+  if (opts.body != null && headers['Content-Length'] === undefined) {
+    headers['Content-Length'] = String(Buffer.byteLength(opts.body));
+  }
+  // Legacy HTTP/1.0 server: close the connection per request rather than reuse a
+  // pooled keep-alive socket.
+  if (headers['Connection'] === undefined) {
+    headers['Connection'] = 'close';
+  }
+
+  return new Promise<HttpResponse>((resolve, reject) => {
+    const req = transport.request(target, { method: opts.method, headers, signal: opts.signal }, (res) => {
+      const chunks: Buffer[] = [];
+      res.on('data', (chunk: Buffer) => chunks.push(chunk));
+      res.on('end', () => resolve({ statusCode: res.statusCode ?? 0, text: Buffer.concat(chunks).toString('utf8') }));
+      res.on('error', reject);
+    });
+    req.on('error', reject);
+    if (opts.body != null) {
+      req.write(opts.body);
+    }
+    req.end();
+  });
+}

--- a/test/abstract-service.test.ts
+++ b/test/abstract-service.test.ts
@@ -1,13 +1,16 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
-import { request as undiciRequest } from 'undici';
+import { httpRequest } from '../src/http-transport';
 import { AbstractService, type IServiceConfig, type RequestOptions } from '../src/abstract-service';
 import { Logger } from '../src/logger';
 import { BadCredentialsError, ProconIpError, RequestTimeoutError } from '../src/errors';
 import { mockFetchOnce, mockFetchNetworkError, mockFetchAbortable, type UndiciResponse } from './helpers/fetch-mock';
 
-// AbstractService.request() now uses undici.request() (not global fetch), so we
-// mock undici's `request` export while keeping its other exports intact.
-vi.mock('undici', async (orig) => ({ ...(await orig<typeof import('undici')>()), request: vi.fn() }));
+// AbstractService.request() delegates to httpRequest() (node:http); mock that
+// module's export while keeping its other exports intact.
+vi.mock('../src/http-transport', async (orig) => ({
+  ...(await orig<typeof import('../src/http-transport')>()),
+  httpRequest: vi.fn(),
+}));
 
 class TestService extends AbstractService {
   _endpoint = '/test';
@@ -23,7 +26,7 @@ const baseConfig: IServiceConfig = {
   timeout: 1000,
 };
 
-afterEach(() => vi.resetAllMocks()); // resets the persistent undici vi.fn() (call history + impls) between tests
+afterEach(() => vi.resetAllMocks()); // resets the persistent httpRequest vi.fn() (call history + impls) between tests
 
 describe('AbstractService', () => {
   it('joins base url and endpoint correctly', () => {
@@ -147,10 +150,10 @@ describe('AbstractService', () => {
 
   it('honours an external AbortSignal and re-throws the original AbortError', async () => {
     // A long-running mock that the test will abort externally.
-    vi.mocked(undiciRequest).mockImplementationOnce(
+    vi.mocked(httpRequest).mockImplementationOnce(
       (_url, opts) =>
         new Promise<UndiciResponse>((_resolve, reject) => {
-          const signal = opts?.signal as AbortSignal | undefined;
+          const signal = opts?.signal;
           signal?.addEventListener('abort', () => {
             const err = new Error('aborted');
             err.name = 'AbortError';

--- a/test/abstract-service.wire.test.ts
+++ b/test/abstract-service.wire.test.ts
@@ -1,26 +1,23 @@
-// REAL-WIRE regression test — intentionally does NOT mock undici.
+// REAL-WIRE regression test — intentionally does NOT mock the transport. It
+// drives the real `node:http` path (see src/http-transport.ts) against a local
+// server and asserts the exact bytes on the wire.
 //
-// This guards against the two concrete bugs that silently broke relay/DMX
-// writes on the ProCon.IP controller's legacy firmware:
+// Guards the concrete bugs that silently broke relay/DMX writes on the
+// ProCon.IP's case-sensitive legacy firmware:
 //
-//   1. Browser-only request headers. When AbstractService.request() used the
-//      WHATWG `fetch()`, Node injected `sec-fetch-mode`, `accept`,
-//      `accept-language`, `user-agent`, `content-type`, etc. onto the wire.
-//      The firmware answered such writes with "200 done" but silently ignored
-//      them. Switching to `undici.request()` sends ONLY the headers we set.
-//      This test drives the *real* undici path against a local node:http
-//      server and asserts those fetch-injected headers are absent — so it goes
-//      red the moment anyone switches `request()` back to `fetch()`.
+//   1. Header-name casing. The firmware only honours `Authorization` and
+//      `Content-Length` capitalised. WHATWG `fetch()` and `undici` both
+//      lowercase the header names they generate (and `fetch()` additionally
+//      injects browser-only headers), so writes were dropped with a bogus
+//      "200 done". `node:http` preserves our casing. This test asserts
+//      `Authorization` and `Content-Length` reach the wire capitalised (via
+//      `req.rawHeaders`, since node lowercases `req.headers`) and that no
+//      browser-only headers appear.
 //
 //   2. Comma encoding. The controller needs a LITERAL comma in bodies like
 //      `ENA=7,2&MANUAL=1`; a percent-encoded `%2C` makes the firmware reset
 //      the connection. This test asserts the received body is byte-for-byte
 //      `ENA=7,2&MANUAL=1`.
-//
-// NOTE on `connection: keep-alive`: undici sends that header too (verified
-// against a real socket), so it is NOT a fetch-vs-undici discriminator and is
-// deliberately not asserted here. The `sec-fetch-*` / `accept-language` /
-// `accept` / `user-agent` headers below ARE fetch-only and do the guarding.
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import http from 'node:http';
@@ -91,7 +88,7 @@ beforeEach(() => {
   behavior = { status: 200, body: 'done', delayMs: 0 };
 });
 
-describe('AbstractService real-wire request (undici, no mocks)', () => {
+describe('AbstractService real-wire request (node:http, no mocks)', () => {
   it('POSTs a clean request: no browser-injected headers, literal comma preserved', async () => {
     const config: IServiceConfig = { controllerUrl: baseUrl, basicAuth: false, timeout: 5000 };
     const svc = new WireService(config, new Logger());
@@ -109,9 +106,16 @@ describe('AbstractService real-wire request (undici, no mocks)', () => {
     expect(got.body).toBe('ENA=7,2&MANUAL=1');
     expect(got.body).not.toContain('%2C');
 
-    // (2) The headers that WHATWG fetch() injects and undici does NOT must be
-    //     absent. If someone reverts request() to fetch(), these reappear and
-    //     this test fails.
+    // (2) `Content-Length` must reach the wire CAPITALISED. The firmware ignores
+    //     the body of a write carrying a lowercase `content-length` (which undici
+    //     emits) — dropping the write while still answering 200. node lowercases
+    //     `req.headers`, so assert against the raw wire names.
+    expect(got.rawHeaders).toContain('Content-Length');
+    expect(got.rawHeaders).not.toContain('content-length');
+
+    // (3) The browser-only headers that WHATWG fetch() injects must be absent.
+    //     If someone routes request() through fetch(), these reappear and this
+    //     test fails.
     expect(got.headers['sec-fetch-mode']).toBeUndefined();
     expect(got.headers['sec-fetch-dest']).toBeUndefined();
     expect(got.headers['sec-fetch-site']).toBeUndefined();

--- a/test/command.service.test.ts
+++ b/test/command.service.test.ts
@@ -1,11 +1,14 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
-import { request as undiciRequest } from 'undici';
+import { httpRequest } from '../src/http-transport';
 import { CommandService } from '../src/command.service';
 import { Logger } from '../src/logger';
 import { mockFetchOnce, mockUndiciResponse } from './helpers/fetch-mock';
 
-// AbstractService.request() uses undici.request(); mock that export.
-vi.mock('undici', async (orig) => ({ ...(await orig<typeof import('undici')>()), request: vi.fn() }));
+// AbstractService.request() uses httpRequest() (node:http); mock that export.
+vi.mock('../src/http-transport', async (orig) => ({
+  ...(await orig<typeof import('../src/http-transport')>()),
+  httpRequest: vi.fn(),
+}));
 
 const config = {
   controllerUrl: 'http://example.local',
@@ -13,7 +16,7 @@ const config = {
   timeout: 1000,
 };
 
-afterEach(() => vi.resetAllMocks()); // resets the persistent undici vi.fn() (call history + impls) between tests
+afterEach(() => vi.resetAllMocks()); // resets the persistent httpRequest vi.fn() (call history + impls) between tests
 
 describe('CommandService', () => {
   it('encodes MAN_DOSAGE in the URL and resolves with seconds', async () => {
@@ -26,9 +29,9 @@ describe('CommandService', () => {
 
   it('targets the correct dosage code per helper', async () => {
     const calls: string[] = [];
-    vi.mocked(undiciRequest).mockImplementation((url) => {
+    vi.mocked(httpRequest).mockImplementation((url) => {
       // request() always builds a string URL; narrow for the string[] sink.
-      calls.push(url as string);
+      calls.push(url);
       return Promise.resolve(mockUndiciResponse(200, ''));
     });
     const svc = new CommandService(config, new Logger());
@@ -57,7 +60,7 @@ describe('CommandService', () => {
   });
 
   it('returns -1 after three failures', async () => {
-    vi.mocked(undiciRequest).mockImplementation(() => Promise.resolve(mockUndiciResponse(500, '')));
+    vi.mocked(httpRequest).mockImplementation(() => Promise.resolve(mockUndiciResponse(500, '')));
     const svc = new CommandService(config, new Logger());
     expect(await svc.setChlorineDosage(10)).toBe(-1);
   });

--- a/test/dmx.service.test.ts
+++ b/test/dmx.service.test.ts
@@ -7,14 +7,17 @@ import { GetDmxData } from '../src/get-dmx-data';
 import { Logger } from '../src/logger';
 import { mockFetchOnce } from './helpers/fetch-mock';
 
-// AbstractService.request() uses undici.request(); mock that export.
-vi.mock('undici', async (orig) => ({ ...(await orig<typeof import('undici')>()), request: vi.fn() }));
+// AbstractService.request() uses httpRequest() (node:http); mock that export.
+vi.mock('../src/http-transport', async (orig) => ({
+  ...(await orig<typeof import('../src/http-transport')>()),
+  httpRequest: vi.fn(),
+}));
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const fixture = readFileSync(resolve(__dirname, 'fixtures/get-dmx.csv'), 'utf8');
 const config = { controllerUrl: 'http://example.local', basicAuth: false, timeout: 1000 };
 
-afterEach(() => vi.resetAllMocks()); // resets the persistent undici vi.fn() (call history + impls) between tests
+afterEach(() => vi.resetAllMocks()); // resets the persistent httpRequest vi.fn() (call history + impls) between tests
 
 describe('DmxService', () => {
   it('POSTs form-encoded DMX state to /usrcfg.cgi', async () => {

--- a/test/get-dmx.service.test.ts
+++ b/test/get-dmx.service.test.ts
@@ -7,14 +7,17 @@ import { GetDmxData } from '../src/get-dmx-data';
 import { Logger } from '../src/logger';
 import { mockFetchOnce } from './helpers/fetch-mock';
 
-// AbstractService.request() uses undici.request(); mock that export.
-vi.mock('undici', async (orig) => ({ ...(await orig<typeof import('undici')>()), request: vi.fn() }));
+// AbstractService.request() uses httpRequest() (node:http); mock that export.
+vi.mock('../src/http-transport', async (orig) => ({
+  ...(await orig<typeof import('../src/http-transport')>()),
+  httpRequest: vi.fn(),
+}));
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const fixture = readFileSync(resolve(__dirname, 'fixtures/get-dmx.csv'), 'utf8');
 const config = { controllerUrl: 'http://example.local', basicAuth: false, timeout: 1000 };
 
-afterEach(() => vi.resetAllMocks()); // resets the persistent undici vi.fn() (call history + impls) between tests
+afterEach(() => vi.resetAllMocks()); // resets the persistent httpRequest vi.fn() (call history + impls) between tests
 
 describe('GetDmxService', () => {
   it('GETs /GetDmx.csv and returns GetDmxData', async () => {

--- a/test/get-state.service.test.ts
+++ b/test/get-state.service.test.ts
@@ -2,14 +2,17 @@ import { describe, it, expect, afterEach, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { request as undiciRequest } from 'undici';
+import { httpRequest } from '../src/http-transport';
 import { GetStateService, type IGetStateServiceConfig } from '../src/get-state.service';
 import { Logger } from '../src/logger';
 import { GetStateData } from '../src/get-state-data';
 import { mockFetchOnce, mockFetchNetworkError, mockUndiciResponse, type UndiciResponse } from './helpers/fetch-mock';
 
-// AbstractService.request() uses undici.request(); mock that export.
-vi.mock('undici', async (orig) => ({ ...(await orig<typeof import('undici')>()), request: vi.fn() }));
+// AbstractService.request() uses httpRequest() (node:http); mock that export.
+vi.mock('../src/http-transport', async (orig) => ({
+  ...(await orig<typeof import('../src/http-transport')>()),
+  httpRequest: vi.fn(),
+}));
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const fixture = readFileSync(resolve(__dirname, 'fixtures/get-state.csv'), 'utf8');
@@ -21,7 +24,7 @@ const config: IGetStateServiceConfig = {
   errorTolerance: 2,
 };
 
-afterEach(() => vi.resetAllMocks()); // resets the persistent undici vi.fn() (call history + impls) between tests
+afterEach(() => vi.resetAllMocks()); // resets the persistent httpRequest vi.fn() (call history + impls) between tests
 
 describe('GetStateService', () => {
   it('parses a valid CSV response into GetStateData', async () => {
@@ -50,7 +53,7 @@ describe('GetStateService', () => {
     vi.useFakeTimers();
     let pending!: () => void;
     const fetchSpy = vi
-      .mocked(undiciRequest)
+      .mocked(httpRequest)
       .mockImplementation(
         () => new Promise<UndiciResponse>((resolve) => (pending = () => resolve(mockUndiciResponse(200, fixture)))),
       );
@@ -67,7 +70,7 @@ describe('GetStateService', () => {
 
   it('start() refreshes callbacks but does not duplicate the poll loop when already running', () => {
     vi.useFakeTimers();
-    vi.mocked(undiciRequest).mockImplementation(
+    vi.mocked(httpRequest).mockImplementation(
       () =>
         new Promise<UndiciResponse>(() => {
           /* never resolves */
@@ -155,7 +158,7 @@ describe('GetStateService', () => {
     // The whole point of stopOnError is "tell me and then stop" -- if the
     // internal stop() ran first it would clear _errorCallback and silently
     // swallow the very notification the consumer asked for.
-    vi.mocked(undiciRequest).mockImplementation(() => Promise.reject(new Error('boom')));
+    vi.mocked(httpRequest).mockImplementation(() => Promise.reject(new Error('boom')));
     const onError = vi.fn();
     // Tiny updateInterval so we don't wait long for the second tick (the
     // second consecutive same-message failure is what triggers the
@@ -171,7 +174,7 @@ describe('GetStateService', () => {
     // Race: start a poll, fail the in-flight request, but call stop() BEFORE
     // the rejection lands. The error callback must not fire afterwards.
     let rejectFetch!: (e: Error) => void;
-    vi.mocked(undiciRequest).mockImplementation(
+    vi.mocked(httpRequest).mockImplementation(
       () => new Promise<UndiciResponse>((_resolve, reject) => (rejectFetch = reject)),
     );
     const onError = vi.fn();
@@ -189,7 +192,7 @@ describe('GetStateService', () => {
     // see overlapping callbacks. With it, only one tick fires before stop().
     vi.useFakeTimers();
     let resolveFetch!: (r: UndiciResponse) => void;
-    vi.mocked(undiciRequest).mockImplementation(() => new Promise<UndiciResponse>((r) => (resolveFetch = r)));
+    vi.mocked(httpRequest).mockImplementation(() => new Promise<UndiciResponse>((r) => (resolveFetch = r)));
     const cb = vi.fn();
     const svc = new GetStateService({ ...config, updateInterval: 50 }, new Logger());
     svc.start(cb);

--- a/test/helpers/fetch-mock.ts
+++ b/test/helpers/fetch-mock.ts
@@ -1,5 +1,5 @@
 import { vi, type MockInstance } from 'vitest';
-import { request as undiciRequest } from 'undici';
+import { httpRequest, type HttpResponse } from '../../src/http-transport';
 
 export interface MockResponse {
   status?: number;
@@ -9,53 +9,51 @@ export interface MockResponse {
 }
 
 /**
- * The value `undici.request()` resolves to (`Dispatcher.ResponseData`). Used to
- * type the mock implementations so `AbstractService.request()` — which consumes
- * `res.statusCode` and `res.body.{text,dump}()` — is driven with a faithful shape.
+ * The value {@link httpRequest} resolves to. `AbstractService.request()` consumes
+ * `res.statusCode` and `res.text`, so the mocks are driven with that shape.
  */
-export type UndiciResponse = Awaited<ReturnType<typeof undiciRequest>>;
-
-type UndiciSpy = MockInstance<typeof undiciRequest>;
+export type MockedResponse = HttpResponse;
 
 /**
- * Build an object shaped like undici's response with just enough of `body`
- * implemented for the code under test to consume it. Cast because we only
- * populate the fields `AbstractService.request()` actually touches.
+ * Historical alias — the transport used to be `undici`; the tests still refer to
+ * the resolved value by this name. Kept to avoid churn across the service tests.
+ * @deprecated Use {@link MockedResponse}.
  */
-export function mockUndiciResponse(status: number, body = ''): UndiciResponse {
-  return {
-    statusCode: status,
-    headers: {},
-    body: {
-      text: (): Promise<string> => Promise.resolve(body),
-      json: (): Promise<unknown> => Promise.resolve(JSON.parse(body) as unknown),
-      arrayBuffer: (): Promise<ArrayBufferLike> => Promise.resolve(new TextEncoder().encode(body).buffer),
-      dump: (): Promise<undefined> => Promise.resolve(undefined),
-    },
-  } as unknown as UndiciResponse;
+export type UndiciResponse = HttpResponse;
+
+type HttpSpy = MockInstance<typeof httpRequest>;
+
+/** Build the object {@link httpRequest} resolves to for the code under test. */
+export function mockHttpResponse(status: number, text = ''): HttpResponse {
+  return { statusCode: status, text };
 }
 
 /**
+ * Historical alias of {@link mockHttpResponse}.
+ * @deprecated Use {@link mockHttpResponse}.
+ */
+export const mockUndiciResponse = mockHttpResponse;
+
+/**
  * Queue a single successful (or arbitrary-status) response on the mocked
- * `undici.request`. Returns the mock instance so callers can inspect
+ * `httpRequest`. Returns the mock instance so callers can inspect
  * `mock.calls[i]` = `[url, opts]` where `opts` = `{ method, headers, body, signal }`.
  */
-export function mockFetchOnce(res: MockResponse): UndiciSpy {
-  const spy = vi.mocked(undiciRequest);
-  spy.mockImplementationOnce(async (): Promise<UndiciResponse> => {
+export function mockFetchOnce(res: MockResponse): HttpSpy {
+  const spy = vi.mocked(httpRequest);
+  spy.mockImplementationOnce(async (): Promise<HttpResponse> => {
     if (res.delayMs) await new Promise((r) => setTimeout(r, res.delayMs));
-    return mockUndiciResponse(res.status ?? 200, res.body ?? '');
+    return mockHttpResponse(res.status ?? 200, res.body ?? '');
   });
   return spy;
 }
 
 /**
- * Queue a single network-layer failure. undici surfaces transport errors as a
- * plain `Error` (unlike WHATWG `fetch`, which throws `TypeError`), so that is
- * what we throw here; `AbstractService.request()` re-throws it unchanged.
+ * Queue a single network-layer failure. The transport surfaces such errors as a
+ * plain `Error`; `AbstractService.request()` re-throws it unchanged.
  */
-export function mockFetchNetworkError(message = 'network'): UndiciSpy {
-  const spy = vi.mocked(undiciRequest);
+export function mockFetchNetworkError(message = 'network'): HttpSpy {
+  const spy = vi.mocked(httpRequest);
   spy.mockImplementationOnce((): never => {
     throw new Error(message);
   });
@@ -67,14 +65,13 @@ export function mockFetchNetworkError(message = 'network'): UndiciSpy {
  * immediately (with an `AbortError`) if the request's `signal` fires first.
  * Lets a test drive the timeout / abort paths of `AbstractService.request()`.
  */
-export function mockFetchAbortable(delayMs: number): UndiciSpy {
-  const spy = vi.mocked(undiciRequest);
+export function mockFetchAbortable(delayMs: number): HttpSpy {
+  const spy = vi.mocked(httpRequest);
   spy.mockImplementationOnce(
     (_url, opts) =>
-      new Promise<UndiciResponse>((resolve, reject) => {
-        const t = setTimeout(() => resolve(mockUndiciResponse(200, 'late')), delayMs);
-        const signal = opts?.signal as AbortSignal | undefined;
-        signal?.addEventListener('abort', () => {
+      new Promise<HttpResponse>((resolve, reject) => {
+        const t = setTimeout(() => resolve(mockHttpResponse(200, 'late')), delayMs);
+        opts.signal?.addEventListener('abort', () => {
           clearTimeout(t);
           const err = new Error('aborted');
           err.name = 'AbortError';

--- a/test/set-state.service.test.ts
+++ b/test/set-state.service.test.ts
@@ -3,8 +3,11 @@ import { SetStateService } from '../src/set-state.service';
 import { Logger } from '../src/logger';
 import { mockFetchOnce } from './helpers/fetch-mock';
 
-// AbstractService.request() uses undici.request(); mock that export.
-vi.mock('undici', async (orig) => ({ ...(await orig<typeof import('undici')>()), request: vi.fn() }));
+// AbstractService.request() uses httpRequest() (node:http); mock that export.
+vi.mock('../src/http-transport', async (orig) => ({
+  ...(await orig<typeof import('../src/http-transport')>()),
+  httpRequest: vi.fn(),
+}));
 
 const config = {
   controllerUrl: 'http://example.local',
@@ -12,7 +15,7 @@ const config = {
   timeout: 1000,
 };
 
-afterEach(() => vi.resetAllMocks()); // resets the persistent undici vi.fn() (call history + impls) between tests
+afterEach(() => vi.resetAllMocks()); // resets the persistent httpRequest vi.fn() (call history + impls) between tests
 
 describe('SetStateService', () => {
   it('sends R{n}=1 and RT{n}=duration*1000', async () => {

--- a/test/usrcfg-cgi.service.test.ts
+++ b/test/usrcfg-cgi.service.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
-import { request as undiciRequest } from 'undici';
+import { httpRequest } from '../src/http-transport';
 import { UsrcfgCgiService } from '../src/usrcfg-cgi.service';
 import { GetStateService, type IGetStateServiceConfig } from '../src/get-state.service';
 import { RelayDataInterpreter } from '../src/relay-data-interpreter';
@@ -10,8 +10,11 @@ import { GetStateCategory } from '../src/get-state-data';
 import { Logger } from '../src/logger';
 import { mockFetchOnce, mockUndiciResponse } from './helpers/fetch-mock';
 
-// AbstractService.request() uses undici.request(); mock that export.
-vi.mock('undici', async (orig) => ({ ...(await orig<typeof import('undici')>()), request: vi.fn() }));
+// AbstractService.request() uses httpRequest() (node:http); mock that export.
+vi.mock('../src/http-transport', async (orig) => ({
+  ...(await orig<typeof import('../src/http-transport')>()),
+  httpRequest: vi.fn(),
+}));
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const fixture = readFileSync(resolve(__dirname, 'fixtures/get-state.csv'), 'utf8');
@@ -23,7 +26,7 @@ const config: IGetStateServiceConfig = {
   errorTolerance: 2,
 };
 
-afterEach(() => vi.resetAllMocks()); // resets the persistent undici vi.fn() (call history + impls) between tests
+afterEach(() => vi.resetAllMocks()); // resets the persistent httpRequest vi.fn() (call history + impls) between tests
 
 async function buildService() {
   mockFetchOnce({ body: fixture });
@@ -38,9 +41,9 @@ describe('UsrcfgCgiService', () => {
   it('POSTs ENA=<on>,<auto>&MANUAL=1 form-encoded body to /usrcfg.cgi', async () => {
     const { svc, getStateService } = await buildService();
     // Each set* call fires TWO requests: the POST + a subsequent GetState refresh.
-    const spy = vi.mocked(undiciRequest);
+    const spy = vi.mocked(httpRequest);
     spy.mockImplementation((url) => {
-      const u = url as string;
+      const u = url;
       const body = u.includes('/usrcfg.cgi') ? '' : fixture;
       return Promise.resolve(mockUndiciResponse(200, body));
     });
@@ -70,8 +73,8 @@ describe('UsrcfgCgiService', () => {
     // immediately after the /usrcfg.cgi POST.
     const { svc, getStateService } = await buildService();
     const calls: string[] = [];
-    vi.mocked(undiciRequest).mockImplementation((url) => {
-      const u = url as string;
+    vi.mocked(httpRequest).mockImplementation((url) => {
+      const u = url;
       calls.push(u);
       const body = u.includes('/usrcfg.cgi') ? '' : fixture;
       return Promise.resolve(mockUndiciResponse(200, body));
@@ -86,8 +89,8 @@ describe('UsrcfgCgiService', () => {
 
   it('setOn / setOff / setAuto all reach the endpoint', async () => {
     const { svc, getStateService } = await buildService();
-    vi.mocked(undiciRequest).mockImplementation((url) => {
-      const u = url as string;
+    vi.mocked(httpRequest).mockImplementation((url) => {
+      const u = url;
       const body = u.includes('/usrcfg.cgi') ? '' : fixture;
       return Promise.resolve(mockUndiciResponse(200, body));
     });


### PR DESCRIPTION
## The bug (the real one behind 2.1.1–2.1.3)

Relay and DMX **writes** return `200 "done"` but **never apply** — the value is gone on the next read, and never shows in the ProCon.IP's own UI.

## Root cause — proven live

The controller is an **HTTP/1.0 server that is case-sensitive on header names**, and it reads a POST body **only** when the length header is spelled **`Content-Length`**. `undici` (and the global `fetch`) lowercase the header names *they generate*, so every write went out with **`content-length`** → the firmware ignored the body and silently no-op'd the write while still answering `200 "done"`.

Same class as the `Authorization` casing fixed in 2.1.3 — but one layer deeper, on a header the HTTP client generates and won't let us re-case. Isolated on a real ProCon.IP V.1.7.6 via a raw socket:

| `Content-Length:` | wire | write applies? |
|---|---|---|
| `Content-Length` (capital) | curl / browser / node:http | **✅ sticks** |
| `content-length` (lower) | undici | **❌ ignored (200)** |

## Fix

Replace `undici` with **Node's built-in `http`/`https`** (`src/http-transport.ts`), which preserves the exact casing of every header we set and adds only a capitalised `Host` (and no browser junk — that was `fetch`'s vice, not `node:http`'s; wire-captured to confirm). **`undici` is removed — the package is now zero runtime dependencies.**

## Verified end-to-end (not just a 200)

Against the real controller, through the **built** library: `DmxService.set(CH01=123)` → `GetDmxService.update()` reads back `123` (before this fix: stayed unchanged). Wire capture confirms `Content-Length` + `Authorization` go out capitalised and no `sec-fetch-*`/`accept`/`user-agent` are added.

## Tests

Real-wire regression now asserts the outgoing `Content-Length` name is capitalised (`req.rawHeaders`). Service unit tests mock the new `httpRequest` seam instead of `undici`. 125 tests pass; build/lint/typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)